### PR TITLE
Use anyhow crate for error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 name = "cri"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "prost",
  "tokio",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,11 @@ name = "criserver"
 path = "src/server.rs"
 
 [dependencies]
+anyhow = "1.0.32"
 tonic = "0.3"
 prost = "0.6"
 tokio = { version = "0.2", features = ["macros"] }
 
 [build-dependencies]
+anyhow = "1.0.32"
 tonic-build = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
-use tonic_build;
+use anyhow::{Context, Result};
+use tonic_build::compile_protos;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("proto/criapi.proto")?;
-    Ok(())
+fn main() -> Result<()> {
+    compile_protos("proto/criapi.proto").context("compile CRI protocol buffers")
 }


### PR DESCRIPTION
To simplify error handling we can utilize the `anyhow` crate:
https://github.com/dtolnay/anyhow

This means we can add an error context and reduce the type overhead in
function signatures. It also formats the errors in a more sane way, for
example if build.rs would fail:

```
  Error: compile CRI protocol buffers

  Caused by:
      No such file or directory (os error 2)
```