### PR TITLE
Add first sandbox abstraction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod config;
 mod criapi;
 mod image_service;
 mod runtime_service;
+mod sandbox;
 mod server;
 
 pub use config::Config;

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -1,0 +1,46 @@
+use anyhow::Result;
+use std::fmt;
+
+mod pinned;
+
+pub trait Sandbox {
+    /// Create sets-up a new sandbox.
+    fn create() -> Result<Self>
+    where
+        Self: Sized;
+
+    /// Start runs a previously created sandbox.
+    fn start(&mut self) -> Result<()>;
+
+    /// Stop a previously started sandbox.
+    fn stop(&mut self) -> Result<()>;
+
+    /// Remove a stopped sandbox.
+    fn remove(self);
+
+    /// Retrieve the current state of the sandbox.
+    fn state(&self) -> State;
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Possible states a sandbox can have.
+pub enum State {
+    /// A sandbox is in `Created` state after the `create()` method has been called.
+    Created,
+
+    /// A sandbox is in `Started` state after the `start()` method has been called.
+    Started,
+
+    /// A sandbox is in `Stopped` state after the `stop()` method has been called.
+    Stopped,
+}
+
+impl fmt::Display for State {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            State::Created => write!(f, "created"),
+            State::Started => write!(f, "started"),
+            State::Stopped => write!(f, "stopped"),
+        }
+    }
+}

--- a/src/sandbox/pinned.rs
+++ b/src/sandbox/pinned.rs
@@ -1,0 +1,72 @@
+use crate::sandbox::{Sandbox, State};
+use anyhow::{bail, Result};
+
+pub struct PinnedSandbox {
+    state: State,
+}
+
+impl Sandbox for PinnedSandbox {
+    fn create() -> Result<Self> {
+        Ok(PinnedSandbox {
+            state: State::Created,
+        })
+    }
+
+    fn start(&mut self) -> Result<()> {
+        if self.state() != State::Created {
+            bail!("not in created state ({})", self.state())
+        }
+        self.state = State::Started;
+        Ok(())
+    }
+
+    fn stop(&mut self) -> Result<()> {
+        if self.state() != State::Started {
+            bail!("not in started state ({})", self.state())
+        }
+        self.state = State::Stopped;
+        Ok(())
+    }
+
+    fn remove(self) {}
+
+    fn state(&self) -> State {
+        self.state
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn pod_state_success() -> Result<()> {
+        let mut p = PinnedSandbox::create()?;
+        assert_eq!(p.state(), State::Created);
+
+        p.start()?;
+        assert_eq!(p.state(), State::Started);
+
+        p.stop()?;
+        assert_eq!(p.state(), State::Stopped);
+
+        p.remove();
+        Ok(())
+    }
+
+    #[test]
+    fn pod_start_fail_not_in_created_state() -> Result<()> {
+        let mut p = PinnedSandbox::create()?;
+        p.start()?;
+        p.stop()?;
+        assert!(p.start().is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn pod_stop_fail_not_in_stopped_state() -> Result<()> {
+        let mut p = PinnedSandbox::create()?;
+        assert!(p.stop().is_err());
+        Ok(())
+    }
+}


### PR DESCRIPTION

#### What type of PR is this?
/kind design

#### What this PR does / why we need it:
This adds a very first `Sandbox` trait which contains the basic state
management methods. A first implementation `PinnedSandbox` is using the
available states to add some first basic logic around the sandbox life
cycle.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
Could not hold my hands still, sorry. 
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
