### PR TITLE
Add context to socket dir creation error

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -43,7 +43,10 @@ impl Server {
         if sock_path.exists() {
             fs::remove_file(sock_path).await?;
         } else {
-            fs::create_dir_all(sock_path.parent().context("get socket path directory")?).await?;
+            let sock_dir = sock_path.parent().context("get socket path directory")?;
+            fs::create_dir_all(sock_dir)
+                .await
+                .context(format!("create socket dir {}", sock_dir.display()))?;
         }
 
         let mut uds = UnixListener::bind(&self.config.sock_path())?;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The resulting error message now provides more information if the socket
directory creation fails:

```
Unable to run server: create socket dir /var/run/cri: Permission denied (os error 13)
```
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
