### PR TITLE
Enhance sandbox ready() docs

### DIFF
--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -61,7 +61,9 @@ pub trait Pod {
         Ok(())
     }
 
-    // Returns whether a sandbox is ready or not
+    // Returns whether a sandbox is ready or not. A sandbox should be `ready()` if running, which
+    // means that a previous call to `run()` was successful and it has not been neither `stopped()`
+    // nor already `removed()`.
     fn ready(&mut self, _: &SandboxData) -> Result<bool> {
         Ok(false)
     }
@@ -94,7 +96,7 @@ where
     }
 
     #[allow(dead_code)]
-    /// Wrapper for the implementations `remove` method
+    /// Wrapper for the implementations `ready` method
     pub fn ready(&mut self) -> Result<bool> {
         self.implementation.ready(&self.data)
     }
@@ -206,18 +208,18 @@ pub mod tests {
             .build()
             .map_err(|e| format_err!("build sandbox: {}", e))?;
 
-        assert!(!sandbox.ready().unwrap());
+        assert!(!sandbox.ready()?);
         sandbox.run()?;
         assert!(sandbox.implementation.run_called);
-        assert!(sandbox.ready().unwrap());
+        assert!(sandbox.ready()?);
 
         sandbox.stop()?;
         assert!(sandbox.implementation.stop_called);
-        assert!(!sandbox.ready().unwrap());
+        assert!(!sandbox.ready()?);
 
         sandbox.remove()?;
         assert!(sandbox.implementation.remove_called);
-        assert!(!sandbox.ready().unwrap());
+        assert!(!sandbox.ready()?);
 
         Ok(())
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind documentation

#### What this PR does / why we need it:
Clarify in the trait when a sandbox should be ready and when not.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
