### PR TITLE
Make socket path work in rootless mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
+name = "cc"
+version = "1.0.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66120af515773fb005778dc07c261bd201ec8ce50bd6e7144c927753fe013381"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,7 +142,9 @@ dependencies = [
  "env_logger",
  "futures-util",
  "getset",
+ "lazy_static",
  "log",
+ "nix",
  "prost",
  "serde",
  "serde_json",
@@ -612,6 +620,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "nix"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,9 @@ derive_builder = { git = "https://github.com/colin-kiegel/rust-derive-builder" }
 env_logger = "0.7.1"
 futures-util = "0.3.5"
 getset = "0.1.1"
+lazy_static = "1.4.0"
 log = { version = "0.4.11", features = ["serde", "std"] }
+nix = "0.18.0"
 prost = "0.6.1"
 serde = { version = "1.0.116", features = ["derive"] }
 serde_json = "1.0.57"


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Depending on the user executing the server, we now choose different
locations for the socket path.

For example as user with the UID `1000`:

```
> cargo run -- -h
…
        --sock-path <sock-path>
            The path to the unix socket for the server [env: CRI_SOCK_PATH=]
            [default: /var/run/user/1000/cri/cri.sock]
…
```

And as root:
```
> sudo -E cargo run -- -h
…
        --sock-path <sock-path>
            The path to the unix socket for the server [env: CRI_SOCK_PATH=]
            [default: /var/run/cri/cri.sock]
…
```
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Make `--sock-path` default value depend on the current user who executes the process.
```
