### PR TITLE
Add --log-scope for logging all crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
+ "strum",
  "tempfile",
  "tokio",
  "tokio-test",
@@ -960,6 +961,27 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3924a58d165da3b7b2922c667ab0673c7b5fd52b5c19ea3442747bcb3cd15abe"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2ab682ecdcae7f5f45ae85cd7c1e6c8e68ea42c8a612d47fedf831c037146a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ log = { version = "0.4.11", features = ["serde", "std"] }
 prost = "0.6.1"
 serde = { version = "1.0.116", features = ["derive"] }
 serde_json = "1.0.57"
+strum = { version = "0.19.2", features = ["derive"] }
 tokio = { version = "0.2.22", features = ["full"] }
 tonic = "0.3.1"
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::Config,
+    config::{Config, LogScope},
     criapi::{
         image_service_server::ImageServiceServer, runtime_service_server::RuntimeServiceServer,
     },
@@ -89,10 +89,12 @@ impl Server {
     /// Initialize the logger and set the verbosity to the provided level.
     fn set_logging_verbosity(&self) -> Result<()> {
         // Set the logging verbosity via the env
-        env::set_var(
-            "RUST_LOG",
-            format!("{}={}", crate_name!(), self.config.log_level()),
-        );
+        let level = if self.config.log_scope() == LogScope::Global {
+            self.config.log_level().to_string()
+        } else {
+            format!("{}={}", crate_name!(), self.config.log_level())
+        };
+        env::set_var("RUST_LOG", level);
 
         // Initialize the logger
         env_logger::try_init().context("init env logger")


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature

#### What this PR does / why we need it:
Right now we only log scoped to the current library, which may be not
enough especially when it comes to debugging issues related to
h2/grpc/tokio.

We now add a `--log-scope` flag, which can be used together with
`--log-level` to log all crates as well.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `--log-scope` flag to be able to log on all crates, not only the current lib.
```
