### PR TITLE
Add static binary build to GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,38 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
       - name: Build Release
         run: make build-release
+
+  build-static:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Podman
+        run: |
+          . /etc/os-release
+          echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+          curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get -y upgrade
+          sudo apt-get -y install podman
+          mkdir -p ~/.cargo/git
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-static-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build Release Static
+        run: make build-release-static
+      - uses: actions/upload-artifact@v2
+        with:
+          name: criserver
+          path: target/x86_64-unknown-linux-musl/release/criserver
 
   doc:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,18 @@ build: ## Build the main binary
 build-release: ## Build the main binary in release mode
 	$(CARGO) build --release
 
+.PHONY: build-release-static
+build-release-static: ## Build the main binary in release mode statically linked
+	podman run -it \
+		-v "$(shell pwd)":/volume \
+		-v ~/.cargo/git:/root/.cargo/git \
+		-v ~/.cargo/registry:/root/.cargo/registry \
+		clux/muslrust \
+		bash -c "\
+			rustup component add rustfmt && \
+			make build-release && \
+			strip -s target/x86_64-unknown-linux-musl/release/criserver"
+
 .PHONY: clean
 clean: ## Clean the work tree
 	$(CARGO) clean


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Adding a static binary to have it early on.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added static binary build to GitHub actions artifacts
```
