### PR TITLE
Add basic network abstraction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod config;
 mod cri_service;
 mod criapi;
 mod image_service;
+mod network;
 mod oci_spec;
 mod runtime_service;
 mod sandbox;

--- a/src/network/cni.rs
+++ b/src/network/cni.rs
@@ -1,0 +1,77 @@
+//! A network implementation which does work with the Kubernetes Container Network Interface (CNI).
+
+use anyhow::Result;
+use derive_builder::Builder;
+use getset::Getters;
+use log::{debug, info};
+use std::path::PathBuf;
+
+#[derive(Builder, Default, Getters)]
+#[builder(pattern = "owned", setter(into))]
+/// The pod network implementation based on the Container Network Interface.
+pub struct CNI {
+    #[get]
+    /// The network name of the default network to be used.
+    default_network_name: Option<String>,
+
+    #[get]
+    /// The paths to configuration files.
+    config_paths: Vec<PathBuf>,
+
+    #[get]
+    /// The paths to binary plugins.
+    plugin_paths: Vec<PathBuf>,
+
+    #[builder(default = "false")]
+    #[get]
+    /// Specifies if the network is ready or not
+    ready: bool,
+}
+
+impl CNI {
+    /// Initialize the CNI network
+    pub fn initialize(&mut self) -> Result<()> {
+        info!("Initializing CNI network");
+        debug!("Default network name: {:?}", self.default_network_name());
+
+        let path_bufs_to_string = |x: &[PathBuf]| -> String {
+            x.iter()
+                .map(|x| x.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        debug!(
+            "Configuration paths: {}",
+            path_bufs_to_string(self.config_paths())
+        );
+        debug!("Plugin paths: {}", path_bufs_to_string(self.plugin_paths()));
+
+        self.ready = true;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn initialize_success() -> Result<()> {
+        let mut cni = CNIBuilder::default()
+            .default_network_name(Some("network".into()))
+            .config_paths(["a", "b"].iter().map(PathBuf::from).collect::<Vec<_>>())
+            .plugin_paths(["c", "d"].iter().map(PathBuf::from).collect::<Vec<_>>())
+            .build()?;
+
+        assert!(!cni.ready());
+        assert!(cni.default_network_name.is_some());
+        assert_eq!(cni.config_paths().len(), 2);
+        assert_eq!(cni.plugin_paths().len(), 2);
+
+        cni.initialize()?;
+        assert!(cni.ready());
+
+        Ok(())
+    }
+}

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,0 +1,96 @@
+//! Network types and implementations.
+
+use crate::sandbox::SandboxData;
+use anyhow::Result;
+use derive_builder::Builder;
+
+pub mod cni;
+
+#[derive(Builder)]
+#[builder(pattern = "owned", setter(into))]
+/// Network is the main structure for working with the Container Network Interface.
+/// The implementation `T` can vary and is being defined in the `Pod` trait.
+pub struct Network<T>
+where
+    T: Default,
+{
+    #[builder(default = "T::default()")]
+    /// Trait implementation for the network.
+    implementation: T,
+}
+
+/// Common network behavior trait
+pub trait PodNetwork {
+    /// Start a new network for the provided `SandboxData`.
+    fn start(&mut self, _: &SandboxData) -> Result<()> {
+        Ok(())
+    }
+
+    /// Stop the network of the provided `SandboxData`.
+    fn stop(&mut self, _: &SandboxData) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl<T> Network<T>
+where
+    T: Default + PodNetwork,
+{
+    #[allow(dead_code)]
+    /// Wrapper for the implementations `start` method.
+    pub fn start(&mut self, sandbox_data: &SandboxData) -> Result<()> {
+        self.implementation.start(sandbox_data)
+    }
+
+    #[allow(dead_code)]
+    /// Wrapper for the implementations `stop` method.
+    pub fn stop(&mut self, sandbox_data: &SandboxData) -> Result<()> {
+        self.implementation.stop(sandbox_data)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::sandbox::tests::new_sandbox_data;
+
+    #[derive(Default)]
+    struct Mock {
+        start_called: bool,
+        stop_called: bool,
+    }
+
+    impl PodNetwork for Mock {
+        fn start(&mut self, _: &SandboxData) -> Result<()> {
+            self.start_called = true;
+            Ok(())
+        }
+
+        fn stop(&mut self, _: &SandboxData) -> Result<()> {
+            self.stop_called = true;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn create() -> Result<()> {
+        let implementation = Mock::default();
+
+        assert!(!implementation.start_called);
+        assert!(!implementation.stop_called);
+
+        let mut network = NetworkBuilder::<Mock>::default()
+            .implementation(implementation)
+            .build()?;
+
+        let sandbox_data = new_sandbox_data()?;
+
+        network.start(&sandbox_data)?;
+        assert!(network.implementation.start_called);
+
+        network.stop(&sandbox_data)?;
+        assert!(network.implementation.stop_called);
+
+        Ok(())
+    }
+}

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -128,7 +128,15 @@ where
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use anyhow::format_err;
+
+    pub fn new_sandbox_data() -> Result<SandboxData> {
+        Ok(SandboxDataBuilder::default()
+            .id("uid")
+            .name("name")
+            .namespace("namespace")
+            .attempt(1u32)
+            .build()?)
+    }
 
     #[derive(Default)]
     struct Mock {
@@ -160,17 +168,8 @@ pub mod tests {
     #[test]
     fn create() -> Result<()> {
         let sandbox = SandboxBuilder::<Mock>::default()
-            .data(
-                SandboxDataBuilder::default()
-                    .id("uid")
-                    .name("name")
-                    .namespace("namespace")
-                    .attempt(1u32)
-                    .build()
-                    .map_err(|e| format_err!("build sandbox data: {}", e))?,
-            )
-            .build()
-            .map_err(|e| format_err!("build sandbox: {}", e))?;
+            .data(new_sandbox_data()?)
+            .build()?;
 
         assert_eq!(sandbox.id(), sandbox.data.id());
 
@@ -195,18 +194,9 @@ pub mod tests {
         assert!(!implementation.remove_called);
 
         let mut sandbox = SandboxBuilder::<Mock>::default()
-            .data(
-                SandboxDataBuilder::default()
-                    .id("id")
-                    .name("name")
-                    .namespace("namespace")
-                    .attempt(0u32)
-                    .build()
-                    .map_err(|e| format_err!("build sandbox data: {}", e))?,
-            )
+            .data(new_sandbox_data()?)
             .implementation(implementation)
-            .build()
-            .map_err(|e| format_err!("build sandbox: {}", e))?;
+            .build()?;
 
         assert!(!sandbox.ready()?);
         sandbox.run()?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,6 +4,10 @@ use crate::{
     criapi::{
         image_service_server::ImageServiceServer, runtime_service_server::RuntimeServiceServer,
     },
+    network::{
+        cni::{CNIBuilder, CNI},
+        Network, NetworkBuilder,
+    },
     storage::{default_key_value_storage::DefaultKeyValueStorage, KeyValueStorage},
     unix_stream,
 };
@@ -18,6 +22,7 @@ use tokio::{
     fs,
     signal::unix::{signal, SignalKind},
 };
+
 use tonic::{transport, Request, Status};
 
 /// Server is the main instance to run the Container Runtime Interface
@@ -39,6 +44,8 @@ impl Server {
         // Setup the storage and pass it to the service
         let storage = DefaultKeyValueStorage::open(&self.config.storage_path())?;
         let cri_service = CRIService::new(storage.clone());
+
+        let _network = self.initialize_network().context("init network")?;
 
         // Build a new socket from the config
         let mut uds = self.unix_domain_listener().await?;
@@ -107,6 +114,23 @@ impl Server {
         env_logger::try_init().context("init env logger")
     }
 
+    /// Create a new network and initialize it from the internal configuration.
+    fn initialize_network(&self) -> Result<Network<CNI>> {
+        let mut cni_network = CNIBuilder::default()
+            .default_network_name(self.config.cni_default_network().clone())
+            .config_paths(self.config.cni_config_paths().clone())
+            .plugin_paths(self.config.cni_plugin_paths().clone())
+            .build()
+            .context("build CNI network data")?;
+        cni_network.initialize().context("initialize CNI network")?;
+
+        let network = NetworkBuilder::<CNI>::default()
+            .implementation(cni_network)
+            .build()
+            .context("build CNI network")?;
+        Ok(network)
+    }
+
     /// This function will get called on each inbound request, if a `Status`
     /// is returned, it will cancel the request and return that status to the
     /// client.
@@ -168,6 +192,14 @@ mod tests {
 
         assert!(sut.unix_domain_listener().await.is_err());
 
+        Ok(())
+    }
+
+    #[test]
+    fn initialize_network() -> Result<()> {
+        let config = ConfigBuilder::default().build()?;
+        let sut = Server::new(config);
+        sut.initialize_network()?;
         Ok(())
     }
 }


### PR DESCRIPTION


#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now add a new `Network[Data]` struct as plain data holders for the
more specific `PodNetwork` trait implementation. The default network
implementation will be `CNI`, which can be later on configured via the
CLI.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to #61 
#### Special notes for your reviewer:
None 
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added basic network module for the CNI implementation
```
