### PR TITLE
Add linux namespaces to sandbox data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
+ "bitflags",
  "clap",
  "ctor",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ opt-level = 'z'
 [dependencies]
 anyhow = "1.0.32"
 bincode = "1.3.1"
+bitflags = "1.2.1"
 clap = { git = "https://github.com/clap-rs/clap", features = ["wrap_help"] }
 derive_builder = { git = "https://github.com/colin-kiegel/rust-derive-builder" }
 env_logger = "0.7.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,3 +15,6 @@ mod unix_stream;
 
 pub use config::Config;
 pub use server::Server;
+
+#[macro_use]
+extern crate bitflags;

--- a/src/runtime_service/run_pod_sandbox.rs
+++ b/src/runtime_service/run_pod_sandbox.rs
@@ -1,7 +1,7 @@
 use crate::{
     cri_service::CRIService,
     criapi::{RunPodSandboxRequest, RunPodSandboxResponse},
-    sandbox::{pinned::PinnedSandbox, SandboxBuilder, SandboxDataBuilder},
+    sandbox::{pinned::PinnedSandbox, LinuxNamespaces, SandboxBuilder, SandboxDataBuilder},
 };
 use log::{debug, info};
 use tonic::{Request, Response, Status};
@@ -31,6 +31,7 @@ impl CRIService {
                     .name(metadata.name)
                     .namespace(metadata.namespace)
                     .attempt(metadata.attempt)
+                    .linux_namespaces(LinuxNamespaces::NET)
                     .build()
                     .map_err(|e| {
                         Status::internal(format!("build sandbox data from metadata: {}", e))

--- a/src/runtime_service/run_pod_sandbox.rs
+++ b/src/runtime_service/run_pod_sandbox.rs
@@ -1,6 +1,6 @@
 use crate::{
     cri_service::CRIService,
-    criapi::{RunPodSandboxRequest, RunPodSandboxResponse},
+    criapi::{NamespaceMode, RunPodSandboxRequest, RunPodSandboxResponse},
     sandbox::{pinned::PinnedSandbox, LinuxNamespaces, SandboxBuilder, SandboxDataBuilder},
 };
 use log::{debug, info};
@@ -23,6 +23,30 @@ impl CRIService {
             .metadata
             .ok_or_else(|| Status::invalid_argument("no pod sandbox metadata provided"))?;
 
+        let linux_config = config
+            .linux
+            .ok_or_else(|| Status::invalid_argument("no linux configuration provided"))?;
+
+        let security_context = linux_config
+            .security_context
+            .ok_or_else(|| Status::invalid_argument("no linux security context provided"))?;
+
+        let namespace_options = security_context
+            .namespace_options
+            .ok_or_else(|| Status::invalid_argument("no namespace options provided"))?;
+
+        let mut linux_namespaces = LinuxNamespaces::empty();
+        if namespace_options.network == NamespaceMode::Pod as i32 {
+            linux_namespaces |= LinuxNamespaces::NET;
+            linux_namespaces |= LinuxNamespaces::UTS;
+        }
+        if namespace_options.ipc == NamespaceMode::Pod as i32 {
+            linux_namespaces |= LinuxNamespaces::IPC;
+        }
+        if namespace_options.pid == NamespaceMode::Pod as i32 {
+            linux_namespaces |= LinuxNamespaces::PID;
+        }
+
         // Build a new sandbox from it
         let mut sandbox = SandboxBuilder::<PinnedSandbox>::default()
             .data(
@@ -31,7 +55,7 @@ impl CRIService {
                     .name(metadata.name)
                     .namespace(metadata.namespace)
                     .attempt(metadata.attempt)
-                    .linux_namespaces(LinuxNamespaces::NET)
+                    .linux_namespaces(linux_namespaces)
                     .build()
                     .map_err(|e| {
                         Status::internal(format!("build sandbox data from metadata: {}", e))
@@ -61,7 +85,10 @@ mod tests {
     use super::*;
     use crate::{
         cri_service::tests::new_cri_service,
-        criapi::{runtime_service_server::RuntimeService, PodSandboxConfig, PodSandboxMetadata},
+        criapi::{
+            runtime_service_server::RuntimeService, LinuxPodSandboxConfig,
+            LinuxSandboxSecurityContext, NamespaceOption, PodSandboxConfig, PodSandboxMetadata,
+        },
     };
     use anyhow::Result;
     use std::collections::HashMap;
@@ -84,7 +111,25 @@ mod tests {
                 port_mappings: vec![],
                 labels: HashMap::new(),
                 annotations: HashMap::new(),
-                linux: None,
+                linux: Some(LinuxPodSandboxConfig {
+                    cgroup_parent: String::from("abc-pod.slice"),
+                    sysctls: HashMap::new(),
+                    security_context: Some(LinuxSandboxSecurityContext {
+                        namespace_options: Some(NamespaceOption {
+                            network: 0,
+                            pid: 1,
+                            ipc: 0,
+                            target_id: String::from("container_id"),
+                        }),
+                        selinux_options: None,
+                        run_as_user: None,
+                        run_as_group: None,
+                        readonly_rootfs: false,
+                        supplemental_groups: Vec::new(),
+                        privileged: false,
+                        seccomp_profile_path: String::from("/path/to/seccomp"),
+                    }),
+                }),
             }),
             runtime_handler: "".into(),
         };

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -23,6 +23,18 @@ where
     implementation: T,
 }
 
+bitflags! {
+    pub struct LinuxNamespaces: u32 {
+        const MOUNT = 0b00000001;
+        const CGROUP = 0b00000010;
+        const UTS = 0b000000100;
+        const IPC = 0b00001000;
+        const USER = 0b00010000;
+        const PID = 0b000100000;
+        const NET = 0b001000000;
+    }
+}
+
 #[derive(Builder, Getters)]
 #[builder(pattern = "owned", setter(into))]
 /// SandboxData holds all the data which will be passed around to the `Pod` trait, too.
@@ -43,6 +55,10 @@ pub struct SandboxData {
     /// Sandbox creation attempt. It only changes if the Kubernetes sandbox data changed or dies
     /// because of any error, not if the sandbox creation itself fails.
     attempt: u32,
+
+    #[get = "pub"]
+    /// Linux namespaces held by the Sandbox.
+    linux_namespaces: Option<LinuxNamespaces>,
 }
 
 pub trait Pod {
@@ -112,6 +128,7 @@ where
             .field("name", self.data.name())
             .field("namespace", self.data.namespace())
             .field("attempt", self.data.attempt())
+            .field("linux_namespaces", self.data.linux_namespaces())
             .finish()
     }
 }
@@ -135,6 +152,7 @@ pub mod tests {
             .name("name")
             .namespace("namespace")
             .attempt(1u32)
+            .linux_namespaces(LinuxNamespaces::NET)
             .build()?)
     }
 

--- a/tests/integration_tests/run_pod_sandbox.rs
+++ b/tests/integration_tests/run_pod_sandbox.rs
@@ -1,5 +1,8 @@
 use crate::common::{
-    criapi::{PodSandboxConfig, PodSandboxMetadata, RunPodSandboxRequest, RunPodSandboxResponse},
+    criapi::{
+        LinuxPodSandboxConfig, LinuxSandboxSecurityContext, NamespaceOption, PodSandboxConfig,
+        PodSandboxMetadata, RunPodSandboxRequest, RunPodSandboxResponse,
+    },
     Sut,
 };
 use anyhow::Result;
@@ -25,7 +28,25 @@ async fn run_pod_sandbox_success() -> Result<()> {
             port_mappings: vec![],
             labels: HashMap::new(),
             annotations: HashMap::new(),
-            linux: None,
+            linux: Some(LinuxPodSandboxConfig {
+                cgroup_parent: String::from("abc-pod.slice"),
+                sysctls: HashMap::new(),
+                security_context: Some(LinuxSandboxSecurityContext {
+                    namespace_options: Some(NamespaceOption {
+                        network: 0,
+                        pid: 1,
+                        ipc: 0,
+                        target_id: String::from("container_id"),
+                    }),
+                    selinux_options: None,
+                    run_as_user: None,
+                    run_as_group: None,
+                    readonly_rootfs: false,
+                    supplemental_groups: Vec::new(),
+                    privileged: false,
+                    seccomp_profile_path: String::from("/path/to/seccomp"),
+                }),
+            }),
         }),
         runtime_handler: "".into(),
     });


### PR DESCRIPTION
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>



#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
This PR adds linux namespaces to sandbox data as a building block to implement
pinned namespace sandbox.


```release-note
Add linux namespaces to sandbox data
```
