### PR TITLE
Improve error messages so as to indicate failures

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -84,13 +84,13 @@ impl Server {
                 .await
                 .with_context(|| format!("unable to remove socket file {}", sock_path.display()))?;
         } else {
-            let sock_dir = sock_path.parent().context("get socket path directory")?;
+            let sock_dir = sock_path.parent().context("unable to get socket path directory")?;
             fs::create_dir_all(sock_dir)
                 .await
-                .with_context(|| format!("create socket dir {}", sock_dir.display()))?;
+                .with_context(|| format!("unable to create socket dir {}", sock_dir.display()))?;
         }
 
-        Ok(UnixListener::bind(sock_path).context("bind socket from path")?)
+        Ok(UnixListener::bind(sock_path).context("unable to bind socket from path")?)
     }
 
     /// Initialize the logger and set the verbosity to the provided level.
@@ -120,7 +120,7 @@ impl Server {
         debug!("Cleaning up server");
         storage.persist().context("persist storage")?;
         std::fs::remove_file(self.config.sock_path())
-            .with_context(|| format!("remove socket path {}", self.config.sock_path().display()))?;
+            .with_context(|| format!("unable to remove socket path {}", self.config.sock_path().display()))?;
         Ok(())
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -84,7 +84,9 @@ impl Server {
                 .await
                 .with_context(|| format!("unable to remove socket file {}", sock_path.display()))?;
         } else {
-            let sock_dir = sock_path.parent().context("unable to get socket path directory")?;
+            let sock_dir = sock_path
+                .parent()
+                .context("unable to get socket path directory")?;
             fs::create_dir_all(sock_dir)
                 .await
                 .with_context(|| format!("unable to create socket dir {}", sock_dir.display()))?;
@@ -119,8 +121,12 @@ impl Server {
     fn cleanup(self, mut storage: DefaultKeyValueStorage) -> Result<()> {
         debug!("Cleaning up server");
         storage.persist().context("persist storage")?;
-        std::fs::remove_file(self.config.sock_path())
-            .with_context(|| format!("unable to remove socket path {}", self.config.sock_path().display()))?;
+        std::fs::remove_file(self.config.sock_path()).with_context(|| {
+            format!(
+                "unable to remove socket path {}",
+                self.config.sock_path().display()
+            )
+        })?;
         Ok(())
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup

#### What this PR does / why we need it:

To improve error messages so as to indicate failures.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
