### PR TITLE
Add log_directory to sandbox data

### DIFF
--- a/src/runtime_service/run_pod_sandbox.rs
+++ b/src/runtime_service/run_pod_sandbox.rs
@@ -57,6 +57,7 @@ impl CRIService {
                     .attempt(metadata.attempt)
                     .linux_namespaces(linux_namespaces)
                     .hostname(config.hostname)
+                    .log_directory(config.log_directory)
                     .build()
                     .map_err(|e| {
                         Status::internal(format!("build sandbox data from metadata: {}", e))

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use derive_builder::Builder;
 use getset::Getters;
 use std::fmt;
+use std::path::PathBuf;
 
 #[derive(Builder)]
 #[builder(pattern = "owned", setter(into))]
@@ -63,6 +64,10 @@ pub struct SandboxData {
     #[get = "pub"]
     /// Hostname of the sandbox.
     hostname: String,
+
+    #[get = "pub"]
+    // Path to the directory on the host in which container log files are stored.
+    log_directory: PathBuf,
 }
 
 pub trait Pod {
@@ -134,6 +139,7 @@ where
             .field("attempt", self.data.attempt())
             .field("linux_namespaces", self.data.linux_namespaces())
             .field("hostname", self.data.hostname())
+            .field("log_directory", self.data.log_directory())
             .finish()
     }
 }
@@ -159,6 +165,7 @@ pub mod tests {
             .attempt(1u32)
             .linux_namespaces(LinuxNamespaces::NET)
             .hostname("hostname")
+            .log_directory("log_directory")
             .build()?)
     }
 
@@ -207,6 +214,9 @@ pub mod tests {
         assert!(sandbox_debug.contains(sandbox.data.id()));
         assert!(sandbox_debug.contains(&sandbox.data.attempt().to_string()));
         assert!(sandbox_debug.contains(sandbox.data.hostname()));
+
+        let log_dir = sandbox.data.log_directory().to_str().unwrap();
+        assert!(sandbox_debug.contains(log_dir));
         Ok(())
     }
 

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -215,8 +215,8 @@ pub mod tests {
         assert!(sandbox_debug.contains(&sandbox.data.attempt().to_string()));
         assert!(sandbox_debug.contains(sandbox.data.hostname()));
 
-        let log_dir = sandbox.data.log_directory().to_str().unwrap();
-        assert!(sandbox_debug.contains(log_dir));
+        let log_dir = sandbox.data.log_directory().display().to_string();
+        assert!(sandbox_debug.contains(&log_dir));
         Ok(())
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature

#### What this PR does / why we need it:

Adds log_directory to sandbox data, taken from PodSandboxConfig.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

```
None
```

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
