### PR TITLE
Allow capabilities to be parsed with and without CAP_ prefix

### DIFF
--- a/src/capability.rs
+++ b/src/capability.rs
@@ -1,7 +1,7 @@
 //! Linux capability handling
 
 use std::{collections::HashSet, ops::Deref};
-use strum::{AsRefStr, EnumIter, EnumString, IntoEnumIterator, IntoStaticStr};
+use strum::{AsRefStr, Display, EnumIter, EnumString, IntoEnumIterator, IntoStaticStr};
 
 #[derive(Debug)]
 /// A set of capabilities.
@@ -23,50 +23,61 @@ impl Deref for Capabilities {
     }
 }
 
-#[derive(AsRefStr, IntoStaticStr, Copy, Clone, Debug, EnumIter, EnumString, Eq, Hash, PartialEq)]
+#[derive(
+    AsRefStr, IntoStaticStr, Copy, Clone, Debug, Display, EnumIter, EnumString, Eq, Hash, PartialEq,
+)]
 #[strum(serialize_all = "shouty_snake_case")]
 /// All available capabilities.
 pub enum Capability {
+    #[strum(serialize = "CHOWN", serialize = "CAP_CHOWN")]
     // In a system with the [_POSIX_CHOWN_RESTRICTED] option defined, this
     // overrides the restriction of changing file ownership and group ownership.
-    CapChown,
+    Chown,
 
+    #[strum(serialize = "DAC_OVERRIDE", serialize = "CAP_DAC_OVERRIDE")]
     // Override all DAC access, including ACL execute access if [_POSIX_ACL] is
     // defined. Excluding DAC access covered by CAP_LINUX_IMMUTABLE.
-    CapDacOverride,
+    DacOverride,
 
+    #[strum(serialize = "DAC_READ_SEARCH", serialize = "CAP_DAC_READ_SEARCH")]
     // Overrides all DAC restrictions regarding read and search on files
     // and directories, including ACL restrictions if [_POSIX_ACL] is
     // defined. Excluding DAC access covered by CAP_LINUX_IMMUTABLE.
-    CapDacReadSearch,
+    DacReadSearch,
 
+    #[strum(serialize = "FOWNER", serialize = "CAP_FOWNER")]
     // Overrides all restrictions about allowed operations on files, where
     // file owner ID must be equal to the user ID, except where CAP_FSETID
     // is applicable. It doesn't override MAC and DAC restrictions.
-    CapFowner,
+    Fowner,
 
+    #[strum(serialize = "FSETID", serialize = "CAP_FSETID")]
     // Overrides the following restrictions that the effective user ID
     // shall match the file owner ID when setting the S_ISUID and S_ISGID
     // bits on that file; that the effective group ID (or one of the
     // supplementary group IDs) shall match the file owner ID when setting
     // the S_ISGID bit on that file; that the S_ISUID and S_ISGID bits are
     // cleared on successful return from chown(2) (not implemented).
-    CapFsetid,
+    Fsetid,
 
+    #[strum(serialize = "KILL", serialize = "CAP_KILL")]
     // Overrides the restriction that the real or effective user ID of a
     // process sending a signal must match the real or effective user ID
     // of the process receiving the signal.
-    CapKill,
+    Kill,
 
+    #[strum(serialize = "SETGID", serialize = "CAP_SETGID")]
     // Allows setgid(2) manipulation
     // Allows setgroups(2)
     // Allows forged gids on socket credentials passing.
-    CapSetgid,
+    Setgid,
 
+    #[strum(serialize = "SETUID", serialize = "CAP_SETUID")]
     // Allows set*uid(2) manipulation (including fsuid).
     // Allows forged pids on socket credentials passing.
-    CapSetuid,
+    Setuid,
 
+    #[strum(serialize = "SETPCAP", serialize = "CAP_SETPCAP")]
     // Without VFS support for capabilities:
     //   Transfer any capability in your permitted set to any pid,
     //   remove any capability in your permitted set from any pid
@@ -75,18 +86,22 @@ pub enum Capability {
     //     to the current process' inheritable set
     //   Allow taking bits out of capability bounding set
     //   Allow modification of the securebits for a process
-    CapSetpcap,
+    Setpcap,
 
+    #[strum(serialize = "LINUX_IMMUTABLE", serialize = "CAP_LINUX_IMMUTABLE")]
     // Allow modification of S_IMMUTABLE and S_APPEND file attributes
-    CapLinuxImmutable,
+    LinuxImmutable,
 
+    #[strum(serialize = "NET_BIND_SERVICE", serialize = "CAP_NET_BIND_SERVICE")]
     // Allows binding to TCP/UDP sockets below 1024
     // Allows binding to ATM VCIs below 32
-    CapNetBindService,
+    NetBindService,
 
+    #[strum(serialize = "NET_BROADCAST", serialize = "CAP_NET_BROADCAST")]
     // Allow broadcasting, listen to multicast
-    CapNetBroadcast,
+    NetBroadcast,
 
+    #[strum(serialize = "NET_ADMIN", serialize = "CAP_NET_ADMIN")]
     // Allow interface configuration
     // Allow administration of IP firewall, masquerading and accounting
     // Allow setting debug option on sockets
@@ -100,38 +115,47 @@ pub enum Capability {
     // Allow multicasting
     // Allow read/write of device-specific registers
     // Allow activation of ATM control sockets
-    CapNetAdmin,
+    NetAdmin,
 
+    #[strum(serialize = "NET_RAW", serialize = "CAP_NET_RAW")]
     // Allow use of RAW sockets
     // Allow use of PACKET sockets
     // Allow binding to any address for transparent proxying (also via
     // NET_ADMIN)
-    CapNetRaw,
+    NetRaw,
 
+    #[strum(serialize = "IPC_LOCK", serialize = "CAP_IPC_LOCK")]
     // Allow locking of shared memory segments
     // Allow mlock and mlockall (which doesn't really have anything to do
     // with IPC)
-    CapIpcLock,
+    IpcLock,
 
+    #[strum(serialize = "IPC_OWNER", serialize = "CAP_IPC_OWNER")]
     // Override IPC ownership checks
-    CapIpcOwner,
+    IpcOwner,
 
+    #[strum(serialize = "SYS_MODULE", serialize = "CAP_SYS_MODULE")]
     // Insert and remove kernel modules - modify kernel without limit
-    CapSysModule,
+    SysModule,
 
+    #[strum(serialize = "SYS_RAWIO", serialize = "CAP_SYS_RAWIO")]
     // Allow ioperm/iopl access
     // Allow sending USB messages to any device via /proc/bus/usb
-    CapSysRawio,
+    SysRawio,
 
+    #[strum(serialize = "SYS_CHROOT", serialize = "CAP_SYS_CHROOT")]
     // Allow use of chroot()
-    CapSysChroot,
+    SysChroot,
 
+    #[strum(serialize = "SYS_PTRACE", serialize = "CAP_SYS_PTRACE")]
     // Allow ptrace() of any process
-    CapSysPtrace,
+    SysPtrace,
 
+    #[strum(serialize = "SYS_PACCT", serialize = "CAP_SYS_PACCT")]
     // Allow configuration of process accounting
-    CapSysPacct,
+    SysPacct,
 
+    #[strum(serialize = "SYS_ADMIN", serialize = "CAP_SYS_ADMIN")]
     // Allow configuration of the secure attention key
     // Allow administration of the random device
     // Allow examination and configuration of disk quotas
@@ -169,18 +193,20 @@ pub enum Capability {
     // Allow setting encryption key on loopback filesystem
     // Allow setting zone reclaim policy
     // Allow everything under CAP_BPF and CAP_PERFMON for backward compatibility
-    CapSysAdmin,
+    SysAdmin,
 
+    #[strum(serialize = "SYS_BOOT", serialize = "CAP_SYS_BOOT")]
     // Allow use of reboot()
-    CapSysBoot,
+    SysBoot,
 
+    #[strum(serialize = "SYS_NICE", serialize = "CAP_SYS_NICE")]
     // Allow raising priority and setting priority on other (different
     // UID) processes
     // Allow use of FIFO and round-robin (realtime) scheduling on own
     // processes and setting the scheduling algorithm used by another
     // process.
     // Allow setting cpu affinity on other processes
-    CapSysNice,
+    SysNice,
 
     // Override resource limits. Set resource limits.
     // Override quota limits.
@@ -194,58 +220,80 @@ pub enum Capability {
     // Override max number of consoles on console allocation
     // Override max number of keymaps
     // Control memory reclaim behavior
-    CapSysResource,
+    #[strum(serialize = "SYS_RESOURCE", serialize = "CAP_SYS_RESOURCE")]
+    SysResource,
 
     // Allow manipulation of system clock
     // Allow irix_stime on mips
     // Allow setting the real-time clock
-    CapSysTime,
+    #[strum(serialize = "SYS_TIME", serialize = "CAP_SYS_TIME")]
+    SysTime,
 
     // Allow configuration of tty devices
     // Allow vhangup() of tty
-    CapSysTtyConfig,
+    #[strum(serialize = "SYS_TTY_CONFIG", serialize = "CAP_SYS_TTY_CONFIG")]
+    SysTtyConfig,
 
+    #[strum(serialize = "MKNOD", serialize = "CAP_MKNOD")]
     // Allow the privileged aspects of mknod()
-    CapMknod,
+    Mknod,
 
+    #[strum(serialize = "LEASE", serialize = "CAP_LEASE")]
     // Allow taking of leases on files
-    CapLease,
+    Lease,
 
-    CapAuditWrite,
-    CapAuditControl,
-    CapSetfcap,
+    #[strum(serialize = "AUDIT_WRITE", serialize = "CAP_AUDIT_WRITE")]
+    /// Write records to kernel auditing log (since Linux 2.6.11).
+    AuditWrite,
 
+    #[strum(serialize = "AUDIT_CONTROL", serialize = "CAP_AUDIT_CONTROL")]
+    /// Enable and disable kernel auditing; change auditing filter rules; retrieve auditing status
+    /// and filtering rules (since Linux 2.6.11).
+    AuditControl,
+
+    #[strum(serialize = "SETFCAP", serialize = "CAP_SETFCAP")]
+    /// Set arbitrary capabilities on a file (since Linux 2.6.24).
+    Setfcap,
+
+    #[strum(serialize = "MAC_OVERRIDE", serialize = "CAP_MAC_OVERRIDE")]
     // Override MAC access.
     // The base kernel enforces no MAC policy.
     // An LSM may enforce a MAC policy, and if it does and it chooses
     // to implement capability based overrides of that policy, this is
     // the capability it should use to do so.
-    CapMacOverride,
+    MacOverride,
 
+    #[strum(serialize = "MAC_ADMIN", serialize = "CAP_MAC_ADMIN")]
     // Allow MAC configuration or state changes.
     // The base kernel requires no MAC configuration.
     // An LSM may enforce a MAC policy, and if it does and it chooses
     // to implement capability based checks on modifications to that
     // policy or the data required to maintain it, this is the
     // capability it should use to do so.
-    CapMacAdmin,
+    MacAdmin,
 
+    #[strum(serialize = "SYSLOG", serialize = "CAP_SYSLOG")]
     // Allow configuring the kernel's syslog (printk behaviour)
-    CapSyslog,
+    Syslog,
 
+    #[strum(serialize = "WAKE_ALARM", serialize = "CAP_WAKE_ALARM")]
     // Allow triggering something that will wake the system
-    CapWakeAlarm,
+    WakeAlarm,
 
+    #[strum(serialize = "BLOCK_SUSPEND", serialize = "CAP_BLOCK_SUSPEND")]
     // Allow preventing system suspends
-    CapBlockSuspend,
+    BlockSuspend,
 
+    #[strum(serialize = "AUDIT_READ", serialize = "CAP_AUDIT_READ")]
     // Allow reading the audit log via multicast netlink socket
-    CapAuditRead,
+    AuditRead,
 
+    #[strum(serialize = "PERFMON", serialize = "CAP_PERFMON")]
     // Allow system performance and observability privileged operations
     // using perf_events, i915_perf and other kernel subsystems
-    CapPerfmon,
+    Perfmon,
 
+    #[strum(serialize = "BPF", serialize = "CAP_BPF")]
     // CAP_BPF allows the following BPF operations:
     // - Creating all types of BPF maps
     // - Advanced verifier features
@@ -273,11 +321,12 @@ pub enum Capability {
     //
     // CAP_PERFMON and CAP_BPF are required to load tracing programs.
     // CAP_NET_ADMIN and CAP_BPF are required to load networking programs.
-    CapBpf,
+    Bpf,
 
+    #[strum(serialize = "CHECKPOINT_RESTORE", serialize = "CAP_CHECKPOINT_RESTORE")]
     // Allow checkpoint/restore related operations.
     // Introduced in kernel 5.9
-    CapCheckpointRestore,
+    CheckpointRestore,
 }
 
 #[cfg(test)]
@@ -288,31 +337,46 @@ mod tests {
 
     #[test]
     fn as_ref() {
-        assert_eq!(Capability::CapSysAdmin.as_ref(), "CAP_SYS_ADMIN");
-        assert_eq!(Capability::CapChown.as_ref(), "CAP_CHOWN");
-        assert_eq!(Capability::CapSetgid.as_ref(), "CAP_SETGID");
+        assert_eq!(Capability::SysAdmin.as_ref(), "CAP_SYS_ADMIN");
+        assert_eq!(Capability::Chown.as_ref(), "CAP_CHOWN");
+        assert_eq!(Capability::Setgid.as_ref(), "CAP_SETGID");
+        assert_eq!(Capability::Bpf.as_ref(), "CAP_BPF");
+    }
+
+    #[test]
+    fn to_string() {
+        assert_eq!(Capability::MacAdmin.to_string(), "CAP_MAC_ADMIN");
+        assert_eq!(Capability::MacOverride.to_string(), "CAP_MAC_OVERRIDE");
+        assert_eq!(Capability::SysTtyConfig.to_string(), "CAP_SYS_TTY_CONFIG");
+        assert_eq!(Capability::SysTime.to_string(), "CAP_SYS_TIME");
     }
 
     #[test]
     fn from_str() -> Result<()> {
         assert_eq!(
-            Capability::CapAuditRead,
+            Capability::AuditRead,
             Capability::from_str("CAP_AUDIT_READ")?
         );
+        assert_eq!(Capability::AuditRead, Capability::from_str("AUDIT_READ")?);
+        assert_eq!(Capability::SysNice, Capability::from_str("CAP_SYS_NICE")?);
+        assert_eq!(Capability::SysNice, Capability::from_str("SYS_NICE")?);
         assert_eq!(
-            Capability::CapSysNice,
-            Capability::from_str("CAP_SYS_NICE")?
-        );
-        assert_eq!(
-            Capability::CapCheckpointRestore,
+            Capability::CheckpointRestore,
             Capability::from_str("CAP_CHECKPOINT_RESTORE")?
         );
+        assert_eq!(
+            Capability::CheckpointRestore,
+            Capability::from_str("CHECKPOINT_RESTORE")?
+        );
+        assert_eq!(Capability::Bpf, Capability::from_str("CAP_BPF")?);
+        assert_eq!(Capability::Bpf, Capability::from_str("BPF")?);
+        assert!(Capability::from_str("wrong").is_err());
         Ok(())
     }
 
     #[test]
     fn into_static_str() {
-        let cap: &'static str = Capability::CapFowner.into();
+        let cap: &'static str = Capability::Fowner.into();
         assert_eq!(cap, "CAP_FOWNER");
     }
 

--- a/src/seccomp.rs
+++ b/src/seccomp.rs
@@ -203,19 +203,17 @@ impl Seccomp {
     /// Returns a list of syscalls for a provided capability name.
     fn capability_to_syscalls(&self, capability: Capability) -> &'static [&'static str] {
         match capability {
-            Capability::CapDacReadSearch => &["open_by_handle_at"],
-            Capability::CapSyslog => &["syslog"],
-            Capability::CapSysBoot => &["reboot"],
-            Capability::CapSysChroot => &["chroot"],
-            Capability::CapSysModule => &["delete_module", "init_module", "finit_module"],
-            Capability::CapSysPacct => &["acct"],
-            Capability::CapSysPtrace => {
-                &["kcmp", "process_vm_readv", "process_vm_writev", "ptrace"]
-            }
-            Capability::CapSysRawio => &["iopl", "ioperm"],
-            Capability::CapSysTime => &["settimeofday", "stime", "clock_settime"],
-            Capability::CapSysTtyConfig => &["vhangup"],
-            Capability::CapSysAdmin => &[
+            Capability::DacReadSearch => &["open_by_handle_at"],
+            Capability::Syslog => &["syslog"],
+            Capability::SysBoot => &["reboot"],
+            Capability::SysChroot => &["chroot"],
+            Capability::SysModule => &["delete_module", "init_module", "finit_module"],
+            Capability::SysPacct => &["acct"],
+            Capability::SysPtrace => &["kcmp", "process_vm_readv", "process_vm_writev", "ptrace"],
+            Capability::SysRawio => &["iopl", "ioperm"],
+            Capability::SysTime => &["settimeofday", "stime", "clock_settime"],
+            Capability::SysTtyConfig => &["vhangup"],
+            Capability::SysAdmin => &[
                 "bpf",
                 "clone",
                 "fanotify_init",


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
It is now possible to convert strings into capabilities which contain
and do not contain the `CAP_` prefix. When serializing them back into a
string, we always get a `CAP_` prefixed result.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
