### PR TITLE
Add CNI network storage support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,16 +83,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
-name = "bincode"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
-dependencies = [
- "byteorder",
- "serde",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,7 +179,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bincode",
  "bitflags",
  "clap",
  "crossbeam-channel 0.5.0",
@@ -206,6 +195,7 @@ dependencies = [
  "nix",
  "notify",
  "prost",
+ "rmp-serde",
  "rtnetlink",
  "serde",
  "serde_json",
@@ -1022,6 +1012,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,6 +1321,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f10b46df14cf1ee1ac7baa4d2fbc2c52c0622a4b82fa8740e37bc452ac0184f"
+dependencies = [
+ "byteorder",
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce7d70c926fe472aed493b902010bccc17fa9f7284145cb8772fd22fdb052d8"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ opt-level = 'z'
 [dependencies]
 anyhow = "1.0.33"
 async-trait = "0.1.40"
-bincode = "1.3.1"
 bitflags = "1.2.1"
 clap = { git = "https://github.com/clap-rs/clap", features = ["wrap_help"] }
 crossbeam-channel = "0.5.0"
@@ -38,6 +37,7 @@ log = { version = "0.4.11", features = ["serde", "std"] }
 nix = "0.19.0"
 notify = { version = "5.0.0-pre.3", features = ["serde"] }
 prost = "0.6.1"
+rmp-serde = "0.14.4"
 rtnetlink = "0.5.0"
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.59"

--- a/src/kubernetes/cri/cri_service.rs
+++ b/src/kubernetes/cri/cri_service.rs
@@ -2,22 +2,20 @@
 
 use crate::storage::default_key_value_storage::DefaultKeyValueStorage;
 use anyhow::Result;
+use derive_builder::Builder;
 use log::debug;
 use std::fmt::{Debug, Display};
 use tonic::{Request, Response, Status};
 
-#[derive(Clone)]
+#[derive(Clone, Builder)]
+#[builder(pattern = "owned", setter(into))]
 /// The service implementation for the CRI API
 pub struct CRIService {
+    /// Storage used by the service.
     storage: DefaultKeyValueStorage,
 }
 
 impl CRIService {
-    /// Create a new CRIService with the provided storage.
-    pub fn new(storage: DefaultKeyValueStorage) -> Self {
-        Self { storage }
-    }
-
     /// Debug log a request.
     pub fn debug_request<T>(&self, request: &Request<T>)
     where

--- a/src/network/cni/config.rs
+++ b/src/network/cni/config.rs
@@ -118,7 +118,7 @@ pub struct ConfigFile {
     dns: DNS,
 
     #[getset(get = "pub")]
-    #[serde(skip)]
+    #[serde(default)]
     raw: Vec<u8>,
 }
 

--- a/src/network/cni/mod.rs
+++ b/src/network/cni/mod.rs
@@ -8,11 +8,12 @@ use crate::{
             exec::{DefaultExec, Exec},
             namespace::Namespace,
             netlink::Netlink,
-            plugin::{Plugin, PluginBuilder},
+            plugin::{CNIResult, Plugin, PluginBuilder},
         },
         PodNetwork,
     },
     sandbox::SandboxData,
+    storage::{default_key_value_storage::DefaultKeyValueStorage, KeyValueStorage},
 };
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
@@ -24,6 +25,7 @@ use notify::{
     event::{CreateKind, ModifyKind, RemoveKind},
     Error as NotifyError, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
 };
+use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     ffi::OsStr,
@@ -32,7 +34,7 @@ use std::{
     result,
     sync::Arc,
 };
-use tokio::sync::{RwLock, RwLockReadGuard};
+use tokio::sync::RwLock;
 
 mod config;
 mod exec;
@@ -55,6 +57,10 @@ pub struct CNI {
     #[get]
     /// The pugin search paths to be used.
     plugin_paths: String,
+
+    #[get]
+    /// The storage path to be used for persisting CNI results.
+    storage_path: Option<PathBuf>,
 
     #[get]
     /// The configuration watcher for monitoring config path changes.
@@ -92,6 +98,10 @@ pub struct CNIState {
     #[get]
     /// The plugin search paths to be used.
     plugin_paths: String,
+
+    #[getset(get_mut)]
+    /// The storage instance to be used for persisting CNI results.
+    storage: Option<DefaultKeyValueStorage>,
 }
 
 /// Selector for watcher messages on the receiver channel.
@@ -134,6 +144,16 @@ impl CNI {
         };
         self.state().write().await.default_network_name = self.default_network_name().clone();
         self.load_networks().await.context("load network configs")?;
+
+        // Setup the storage if a path is set
+        match self.storage_path() {
+            Some(path) => {
+                trace!("Setup CNI storage in {}", path.display());
+                self.state().write().await.storage =
+                    Some(DefaultKeyValueStorage::open(path).context("open storage path")?)
+            }
+            None => warn!("Not using CNI storage, cannot persist network results"),
+        }
 
         // Create a config watcher
         let (tx, rx) = crossbeam_channel::unbounded();
@@ -439,9 +459,8 @@ impl CNI {
     /// Retrieve necessary data for network start/stop.
     async fn get_start_stop_data<'a, 'b>(
         &'b self,
-        state: &'b RwLockReadGuard<'_, CNIState>,
         sandbox_data: &'a SandboxData,
-    ) -> Result<(&'a Path, Namespace, &'b Config)> {
+    ) -> Result<(&'a Path, Namespace)> {
         let network_namespace_path = sandbox_data
             .network_namespace_path()
             .as_ref()
@@ -451,18 +470,13 @@ impl CNI {
             .await
             .context("create network namespace")?;
 
-        let default_network = state
-            .default_network()
-            .as_ref()
-            .context("no default network available")?;
-
-        Ok((network_namespace_path, netns, default_network))
+        Ok((network_namespace_path, netns))
     }
 
     /// Build a CNI plugin for start/stop execution.
-    async fn build_plugin(&self, config: &ConfigFile) -> Result<Plugin> {
+    async fn build_plugin(&self, binary: &str) -> Result<Plugin> {
         let mut plugin = PluginBuilder::default()
-            .binary(config.typ())
+            .binary(binary)
             .build()
             .context("build CNI plugin")?;
         plugin.set_exec(
@@ -482,6 +496,26 @@ impl CNI {
     }
 }
 
+/// A value to be safed in the CNI network storage.
+type StorageValues = Vec<StorageValue>;
+
+#[derive(Builder, Default, Getters, Serialize, Deserialize)]
+#[builder(default, pattern = "owned", setter(into))]
+/// A single storage value.
+struct StorageValue {
+    #[get]
+    /// CNI Plugin binary name.
+    binary_name: String,
+
+    #[get]
+    /// Raw CNI config.
+    raw_cni_config: Vec<u8>,
+
+    #[get]
+    /// The CNI add result.
+    cni_result: CNIResult,
+}
+
 #[async_trait]
 impl PodNetwork for CNI {
     /// Start a new network for the provided `SandboxData`.
@@ -489,15 +523,18 @@ impl PodNetwork for CNI {
         info!("Starting CNI network for sandbox {}", sandbox_data.id());
         // Things intentionally skipped for sake of initial implementation simplicity:
         //
-        // - host network pod handling
         // - host port management
         // - ingress egress bandwidth handling via annotations
 
-        let state = self.state.read().await;
-        let (network_namespace_path, netns, default_network) =
-            self.get_start_stop_data(&state, sandbox_data).await?;
+        let mut state = self.state.write().await;
+        let (network_namespace_path, netns) = self.get_start_stop_data(sandbox_data).await?;
 
-        // Setup loopback interface
+        let default_network = state
+            .default_network()
+            .as_ref()
+            .context("no default network available")?;
+
+        trace!("Setup loopback interface");
         netns
             .run(async move {
                 let netlink = Netlink::new().await?;
@@ -510,9 +547,12 @@ impl PodNetwork for CNI {
             .await
             .context("init loopback interface")?;
 
-        // Add the network via the CNI plugin
+        trace!("Adding networks via plugins");
+        let mut value = vec![];
         for (i, config) in default_network.list().plugins().iter().enumerate() {
-            self.build_plugin(config)
+            // Add the network via the CNI plugin
+            let cni_result = self
+                .build_plugin(config.typ())
                 .await?
                 .add(
                     sandbox_data.id(),
@@ -522,6 +562,22 @@ impl PodNetwork for CNI {
                 )
                 .await
                 .context("add network via plugin")?;
+
+            value.push(
+                StorageValueBuilder::default()
+                    .binary_name(config.typ())
+                    .raw_cni_config(config.raw().as_slice())
+                    .cni_result(cni_result)
+                    .build()
+                    .context("build storage value")?,
+            );
+        }
+
+        if let Some(storage) = state.storage_mut() {
+            trace!("Storing CNI result");
+            storage
+                .insert(sandbox_data.id(), value)
+                .context("insert CNI result into storage")?;
         }
 
         debug!("Started CNI network for sandbox {}", sandbox_data.id());
@@ -531,11 +587,10 @@ impl PodNetwork for CNI {
     /// Stop the network of the provided `SandboxData`.
     async fn stop(&mut self, sandbox_data: &SandboxData) -> Result<()> {
         info!("Stopping CNI network for sandbox {}", sandbox_data.id());
-        let state = self.state.read().await;
-        let (network_namespace_path, netns, default_network) =
-            self.get_start_stop_data(&state, sandbox_data).await?;
+        let mut state = self.state.write().await;
+        let (network_namespace_path, netns) = self.get_start_stop_data(sandbox_data).await?;
 
-        // Tear down loopback interface
+        trace!("Stopping loopback interface");
         netns
             .run(async move {
                 let netlink = Netlink::new().await?;
@@ -548,18 +603,38 @@ impl PodNetwork for CNI {
             .await
             .context("tear down loopback interface")?;
 
-        // Remove the network via the CNI plugin
-        for (i, config) in default_network.list().plugins().iter().enumerate() {
-            self.build_plugin(config)
-                .await?
-                .del(
-                    sandbox_data.id(),
-                    &network_namespace_path.display().to_string(),
-                    &Self::eth(i),
-                    config.raw(),
-                )
-                .await
-                .context("delete network via plugin")?;
+        if let Some(storage) = state.storage_mut() {
+            trace!("Removing all networks");
+
+            let storage_values: StorageValues = storage
+                .get(sandbox_data.id())
+                .context("retrieve sandbox from storage")?
+                .context("sandbox already removed")?;
+
+            trace!(
+                "Got {} networks for sandbox {}",
+                storage_values.len(),
+                sandbox_data.id()
+            );
+
+            for (i, value) in storage_values.iter().enumerate() {
+                // Remove the network via the CNI plugin
+                self.build_plugin(value.binary_name())
+                    .await?
+                    .del(
+                        sandbox_data.id(),
+                        &network_namespace_path.display().to_string(),
+                        &Self::eth(i),
+                        value.raw_cni_config(),
+                    )
+                    .await
+                    .context("delete network via plugin")?;
+            }
+
+            trace!("Removing sandbox from storage");
+            storage
+                .remove(sandbox_data.id())
+                .context("remove sandbox from storage")?;
         }
 
         debug!("Stopped CNI network for sandbox {}", sandbox_data.id());
@@ -567,7 +642,7 @@ impl PodNetwork for CNI {
     }
 
     /// Cleanup the network on server shutdown.
-    fn cleanup(&mut self) -> Result<()> {
+    async fn cleanup(&mut self) -> Result<()> {
         trace!("Stopping watcher");
         self.watcher
             .as_ref()
@@ -575,6 +650,12 @@ impl PodNetwork for CNI {
             .1
             .send(WatcherMessage::Exit)
             .context("send exit signal to watcher thread")?;
+
+        if let Some(storage) = self.state().write().await.storage_mut() {
+            trace!("Persisting CNI storage");
+            storage.persist().context("persist storage")?;
+        }
+
         Ok(())
     }
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -34,7 +34,7 @@ pub trait PodNetwork {
     }
 
     /// Cleanup the network implementation on server shutdown.
-    fn cleanup(&mut self) -> Result<()> {
+    async fn cleanup(&mut self) -> Result<()> {
         Ok(())
     }
 }
@@ -56,8 +56,8 @@ where
     }
 
     /// Cleanup the network implementation on server shutdown.
-    pub fn cleanup(&mut self) -> Result<()> {
-        self.implementation.cleanup()
+    pub async fn cleanup(&mut self) -> Result<()> {
+        self.implementation.cleanup().await
     }
 }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -14,7 +14,7 @@ pub trait KeyValueStorage {
         Self: Sized;
 
     /// Get an arbitrary item from the storage.
-    fn get<K, V>(&mut self, key: K) -> Result<Option<V>>
+    fn get<K, V>(&self, key: K) -> Result<Option<V>>
     where
         K: AsRef<[u8]>,
         V: DeserializeOwned;


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now us a separate storage instance to store the CNI results. These
results will be also used on network teardown, because the config could
have changed in between.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add CNI network storage support
```
