### PR TITLE
Fix dependabot PR CI running twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: ci
-on: [push, pull_request]
+on:
+  pull_request: {}
+  push:
+    branches:
+      - master
 env:
   CARGO_TERM_COLOR: always
 jobs:


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
If dependabot pushes a PR then the CI runs twice because we run it on
push (all branches) as well as on PRs. We now limit the `push` to
`master`, which should avoid this.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
