### PR TITLE
Upload artifacts to GCS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,22 @@ jobs:
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
-      - name: Create artifact tarball
+      - name: Create and upload artifact tarball
         shell: bash
         run: |
             cp src/ffi/ffi.h .
             cp target/release/libcri.a .
-            tar cfz lib-$(git rev-parse --short HEAD).tar.gz ffi.h libcri.a
+
+            VERSION=$(
+              git describe --tags --exact-match 2>/dev/null ||
+              git rev-parse --short HEAD
+            )
+            TARBALL=lib-$VERSION.tar.gz
+
+            tar cfz $TARBALL ffi.h libcri.a
+            gsutil -m cp -n $TARBALL gs://$GCS_BUCKET/lib || true
+        env:
+          GCS_BUCKET: k8s-conform-cri-o
       - uses: actions/upload-artifact@v2
         with:
           name: lib


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Since the GCS authentication is now in place, we upload every binary
artifact to the bucket if we're authenticated. This should only happen
on the master branch and not on forks/PRs.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
